### PR TITLE
Fix error message in html report generation

### DIFF
--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -202,7 +202,7 @@ function annotateStatements(fileCoverage, structuredText) {
             closeSpan = lt + '/span' + gt,
             text;
 
-        if (type === 'no') {
+        if (type === 'no' && structuredText[startLine]) {
             if (endLine !== startLine) {
                 endLine = startLine;
                 endCol = structuredText[startLine].text.originalLength();
@@ -233,7 +233,7 @@ function annotateFunctions(fileCoverage, structuredText) {
             closeSpan = lt + '/span' + gt,
             text;
 
-        if (type === 'no') {
+        if (type === 'no' && structuredText[startLine]) {
             if (endLine !== startLine) {
                 endLine = startLine;
                 endCol = structuredText[startLine].text.originalLength();
@@ -280,7 +280,7 @@ function annotateBranches(fileCoverage, structuredText) {
                 openSpan = lt + 'span class="branch-' + i + ' ' + (meta.skip ? 'cbranch-skip' : 'cbranch-no') + '"' + title('branch not covered') + gt;
                 closeSpan = lt + '/span' + gt;
 
-                if (count === 0) { //skip branches taken
+                if (count === 0 && structuredText[startLine]) { //skip branches taken
                     if (endLine !== startLine) {
                         endLine = startLine;
                         endCol = structuredText[startLine].text.originalLength();


### PR DESCRIPTION
**Description**

Currently, the following error is thrown after creating coverage reports using istanbul: 
`ERROR [coverage]: TypeError: Cannot read property 'text' of undefined`

The error is thrown from the html report generation file, despite reports being correctly generated.

This change modifies 3 conditional statements by ensuring `structuredText[startLine]` exists before entering conditional blocks that reference it. 